### PR TITLE
Fix set-webhook URL in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,13 +12,13 @@ Built top of [Nitro](https://nitro.unjs.io/) and [Telegraf](https://telegraf.js.
 4. Copy `.env.example` to `.env`, and fill in the `BOT_TOKEN` and `TOKEN` in `.env`.
 5. Run `pnpm dev` to start the development server.
 6. Expose your local server to the internet with [Local Port Forwarding of VSCode](https://code.visualstudio.com/docs/editor/port-forwarding) (**set Port Visibility to Public**) or [ngrok](https://ngrok.com/).
-7. Visit https://your-domain.com/telegram-hook?setWebhook=true
+7. Visit https://your-domain.com/set-webhook?token=TOKEN
 8. Send `/start` to your bot.
 
 ## Deployment
 
 1. Deploy on [Vercel](https://vercel.com), [Netlify](https://netlify.com) or [others](https://nitro.unjs.io/deploy), with `BOT_TOKEN` and `TOKEN` environment variables.
-2. Visit https://your-domain.com/telegram-hook?setWebhook=true
+2. Visit https://your-domain.com/set-webhook?token=TOKEN
 3. Send `/start` to your bot.
 
 ## Credits


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/sxzz/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

The links in the README are incorrect, which may confuse a beginner.

### Additional context

- The `/telegram-hook` URL is used to handle Telegram messages.
- The `/set-webhook` URL is used to set up the Telegram Bot to use the URL above for message handling.
